### PR TITLE
Register preconfigured services in CommandAppBuilder extension methods.

### DIFF
--- a/D20Tek.Spectre.Console.Extensions.UnitTests/CommandAppBuilderTests.PreConfigured.cs
+++ b/D20Tek.Spectre.Console.Extensions.UnitTests/CommandAppBuilderTests.PreConfigured.cs
@@ -1,0 +1,126 @@
+﻿//---------------------------------------------------------------------------------------------------------------------
+// Copyright (c) d20Tek.  All rights reserved.
+//---------------------------------------------------------------------------------------------------------------------
+using Autofac;
+using D20Tek.Spectre.Console.Extensions.UnitTests.Mocks;
+using Lamar;
+using LightInject;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ninject;
+using System;
+
+namespace D20Tek.Spectre.Console.Extensions.UnitTests
+{
+    [TestClass]
+    public class CommandAppBuilderTests_PreConfiguredContainers
+    {
+        [TestMethod]
+        public void Run_DIRegistrar()
+        {
+            // arrange
+            var services = new ServiceCollection();
+            var builder = new CommandAppBuilder()
+                              .WithDIContainer(services)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void Run_NinjectRegistrar()
+        {
+            // arrange
+            var container = new StandardKernel();
+            var builder = new CommandAppBuilder()
+                              .WithNinjectContainer(container)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void Run_SimpleInjectorRegistrar()
+        {
+            // arrange
+            var container = new SimpleInjector.Container();
+            var builder = new CommandAppBuilder()
+                              .WithSimpleInjectorContainer(container)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void Run_AutofacRegistrar()
+        {
+            // arrange
+            var container = new ContainerBuilder();
+            var builder = new CommandAppBuilder()
+                              .WithAutofacContainer(container)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void Run_LightInjectRegistrar()
+        {
+            // arrange
+            var container = new ServiceContainer();
+            var builder = new CommandAppBuilder()
+                              .WithLightInjectContainer(container)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void Run_LamarRegistrar()
+        {
+            // arrange
+            var registry = new ServiceRegistry();
+            var builder = new CommandAppBuilder()
+                              .WithLamarContainer(registry)
+                              .WithStartup<MockStartup>()
+                              .WithDefaultCommand<MockCommand>()
+                              .Build();
+
+            // act
+            var result = builder.Run(Array.Empty<string>());
+
+            // assert
+            Assert.AreEqual(0, result);
+        }
+    }
+}

--- a/D20Tek.Spectre.Console.Extensions/D20Tek.Spectre.Console.Extensions.csproj
+++ b/D20Tek.Spectre.Console.Extensions/D20Tek.Spectre.Console.Extensions.csproj
@@ -16,7 +16,7 @@ We also support the CommandAppBuilder for easily creating and running your insta
     <RepositoryUrl>https://github.com/d20Tek/Spectre.Console.Extensions</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Spectre; Spectre.Console; CLI; dependency injection;</PackageTags>
-    <PackageReleaseNotes>Release 1.0.5 - Added support for type registrars and resolvers for Lamar DI framework.
+    <PackageReleaseNotes>Release 1.0.6 - Added optional parameter to all With*Container extension methods to allow container to be passed to CommandAppBuilder.
 For full release notes, please read: https://github.com/d20Tek/Spectre.Console.Extensions/blob/main/ReleaseNotes.md</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/D20Tek.Spectre.Console.Extensions/Injection/CommandAppBuilderExtensions.cs
+++ b/D20Tek.Spectre.Console.Extensions/Injection/CommandAppBuilderExtensions.cs
@@ -16,79 +16,122 @@ namespace D20Tek.Spectre.Console.Extensions
     public static class CommandAppBuilderExtensions
     {
         /// <summary>
-        /// Creates the type registrar based on the DependencyInjector ServiceCollection
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the DependencyInjection ServiceCollection in CommandAppBuilder
+        /// with optional pre-registered services.
         /// </summary>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithDIContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="services">
+        ///     [Optional] Provide pre-registered services, or create new instance when null.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithDIContainer(
+            this CommandAppBuilder builder,
+            IServiceCollection? services = null)
         {
-            var container = new ServiceCollection();
-            builder.Registrar = new DependencyInjectionTypeRegistrar(container);
+            // if no pre-registerd IServiceCollecion specified, create a new empty instance.
+            services ??= new ServiceCollection();
+
+            builder.Registrar = new DependencyInjectionTypeRegistrar(services);
             return builder;
         }
 
         /// <summary>
-        /// Creates the type registrar based on the Ninject StandardKernel
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the Ninject Standard Kernel in CommandAppBuilder
+        /// with optional pre-registered container.
         /// </summary>
-        /// <param name="builder">Builder instance to extend.</param>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithNinjectContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="container">
+        ///     [Optional] Provide pre-registered services kernel. Creates new instance when not specified.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithNinjectContainer(
+            this CommandAppBuilder builder,
+            StandardKernel? container = null)
         {
-            var container = new StandardKernel();
+            // if no pre-registerd StandardKernel specified, create a new empty instance.
+            container ??= new StandardKernel();
+
             builder.Registrar = new NinjectTypeRegistrar(container);
             return builder;
         }
 
         /// <summary>
-        /// Creates the type registrar based on the SimpleInjector Container
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the SimpleInjector Container in CommandAppBuilder
+        /// with optional pre-registered container.
         /// </summary>
-        /// <param name="builder">Builder instance to extend.</param>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithSimpleInjectorContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="container">
+        ///     [Optional] Provide pre-registered services container. Creates new instance when not specified.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithSimpleInjectorContainer(
+            this CommandAppBuilder builder,
+            SimpleInjector.Container? container = null)
         {
-            var container = new SimpleInjector.Container();
+            // if no pre-registerd Container specified, create a new empty instance.
+            container ??= new SimpleInjector.Container();
+
             builder.Registrar = new SimpleInjectorTypeRegistrar(container);
             return builder;
         }
 
         /// <summary>
-        /// Creates the type registrar based on the Autofac ContainerBuilder
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the AutoFac ContainerBuilder in CommandAppBuilder
+        /// with optional pre-registered container.
         /// </summary>
-        /// <param name="builder">Builder instance to extend.</param>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithAutofacContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="container">
+        ///     [Optional] Provide pre-registered services container. Creates new instance when not specified.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithAutofacContainer(
+            this CommandAppBuilder builder,
+            ContainerBuilder? container = null)
         {
-            var container = new ContainerBuilder();
+            // if no pre-registerd ContainerBuilder specified, create a new empty instance.
+            container ??= new ContainerBuilder();
+
             builder.Registrar = new AutofacTypeRegistrar(container);
             return builder;
         }
 
         /// <summary>
-        /// Creates the type registrar based on the LightInject ServiceContainer
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the LightInject ServiceContainer in CommandAppBuilder
+        /// with optional pre-registered container.
         /// </summary>
-        /// <param name="builder">Builder instance to extend.</param>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithLightInjectContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="container">
+        ///     [Optional] Provide pre-registered services container. Creates new instance when not specified.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithLightInjectContainer(
+            this CommandAppBuilder builder,
+            ServiceContainer? container = null)
         {
-            var container = new ServiceContainer();
+            // if no pre-registerd ServiceContainer specified, create a new empty instance.
+            container ??= new ServiceContainer();
+
             builder.Registrar = new LightInjectTypeRegistrar(container);
             return builder;
         }
 
         /// <summary>
-        /// Creates the type registrar based on the Lamar ServiceRegistry
-        /// and sets it in the CommandAppBuilder.
+        /// Creates the type registrar based on the Lamar ServiceRegistry in CommandAppBuilder
+        /// with optional pre-registered service registry.
         /// </summary>
-        /// <param name="builder">Builder instance to extend.</param>
-        /// <returns>Returns the CommandAppBuilder.</returns>
-        public static CommandAppBuilder WithLamarContainer(this CommandAppBuilder builder)
+        /// <param name="builder">CommandAppBuilder to extend.</param>
+        /// <param name="serviceRegistry">
+        ///     [Optional] Provide pre-registered services registry. Creates new instance when not specified.
+        /// </param>
+        /// <returns>Returns the CommandAppBuilder</returns>
+        public static CommandAppBuilder WithLamarContainer(
+            this CommandAppBuilder builder,
+            ServiceRegistry? serviceRegistry = null)
         {
-            var registry = new ServiceRegistry();
-            builder.Registrar = new LamarTypeRegistrar(registry);
+            // if no pre-registerd ServiceRegistry specified, create a new empty instance.
+            serviceRegistry ??= new ServiceRegistry();
+
+            builder.Registrar = new LamarTypeRegistrar(serviceRegistry);
             return builder;
         }
     }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The current releases contain implementations of ITypeRegistrar and ITypeResolver
 
 We also support the CommandAppBuilder to easily create, configure, and run your instance of Spectre.Console.CommandApp.
 
-For future releases, I will continue to investigate integration with other DI frameworks.
+For future releases, I will continue to investigate integration with other DI frameworks and logging integrations.
 
 ## Installation
 This library is a NuGet package so it is easy to add to your project. To install this package into your solution, you can use the NuGet Package Manager. In PM, please use the following command:
 ```  
-PM > Install-Package D20Tek.Spectre.Console.Extensions -Version 1.0.4
+PM > Install-Package D20Tek.Spectre.Console.Extensions -Version 1.0.6
 ``` 
 
 To install in the Visual Studio UI, go to the Tools menu > "Manage NuGet Packages". Then search for D20Tek.Spectre.Console.Extensions and install it from there.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Release v1.0.6
+* Added optional parameter to all With*Container extension methods to allow container to be passed to CommandAppBuilder.
+* If no optional container passed, we still create a new instance of the appropriate container.
+* New unit tests to validate providing optional containers.
+
 ## Release v1.0.5
 * Implemented Lamar type registrar and resolver with unit tests.
 * Implement CommandAppBuilder extension method for Lamar container with unit test.


### PR DESCRIPTION
* Added optional parameter to all With*Container extension methods to allow container to be passed to CommandAppBuilder.
* If no optional container passed, we still create a new instance of the appropriate container.
* New unit tests to validate providing optional containers.
