### PR TITLE
Fix description of verbosity setting.

### DIFF
--- a/.github/workflows/spectre-console-extensions-ci.yml
+++ b/.github/workflows/spectre-console-extensions-ci.yml
@@ -2,7 +2,7 @@ name: ci-build
 
 on:
   push:
-    branches: [ feature/* ]
+    branches: [ feature/*, bug-fix/* ]
   pull_request:
     branches: [ main ]
 

--- a/D20Tek.Spectre.Console.Extensions/Services/ConsoleVerbosityWriter.cs
+++ b/D20Tek.Spectre.Console.Extensions/Services/ConsoleVerbosityWriter.cs
@@ -6,38 +6,55 @@ using Spectre.Console;
 
 namespace D20Tek.Spectre.Console.Extensions.Services
 {
-    internal class ConsoleVerbosityWriter : IVerbosityWriter
+    /// <summary>
+    /// Console output service that respected the set verbosity level.
+    /// </summary>
+    public class ConsoleVerbosityWriter : IVerbosityWriter
     {
         private readonly IAnsiConsole _console;
 
+        /// <inheritdoc/>
         public VerbosityLevel Verbosity { get; set; } = VerbosityLevel.Normal;
 
+        /// <summary>
+        /// Constructor that takes a console object to use for output.
+        /// </summary>
+        /// <param name="console">Console to use for output.</param>
+        /// <exception cref="ArgumentNullException">when console parameter is null.</exception>
         public ConsoleVerbosityWriter(IAnsiConsole console)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
         }
 
+        /// <inheritdoc/>
         public void MarkupDetailed(string text) =>
             this.MarkupLine(text, VerbosityLevel.Detailed);
 
+        /// <inheritdoc/>
         public void MarkupDiagnostics(string text) =>
             this.MarkupLine(text, VerbosityLevel.Diagnostic);
 
+        /// <inheritdoc/>
         public void MarkupNormal(string text) =>
             this.MarkupLine(text, VerbosityLevel.Normal);
 
+        /// <inheritdoc/>
         public void MarkupSummary(string text) =>
             this.MarkupLine(text, VerbosityLevel.Minimal);
 
+        /// <inheritdoc/>
         public void WriteDetailed(string text) =>
             this.WriteLine(text, VerbosityLevel.Detailed);
 
+        /// <inheritdoc/>
         public void WriteDiagnostics(string text) =>
             this.WriteLine(text, VerbosityLevel.Diagnostic);
 
+        /// <inheritdoc/>
         public void WriteNormal(string text) =>
             this.WriteLine(text, VerbosityLevel.Normal);
 
+        /// <inheritdoc/>
         public void WriteSummary(string text) =>
             this.WriteLine(text, VerbosityLevel.Minimal);
 

--- a/D20Tek.Spectre.Console.Extensions/Settings/VerbositySettings.cs
+++ b/D20Tek.Spectre.Console.Extensions/Settings/VerbositySettings.cs
@@ -15,7 +15,7 @@ namespace D20Tek.Spectre.Console.Extensions.Settings
         /// Verbosity level for this command
         /// </summary>
         [CommandOption("-v|--verbosity <VERBOSITY-LEVEL>")]
-        [Description("The verbosity level for this operation (q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]).")]
+        [Description("The verbosity level for this operation: q(uiet), m(inimal), n(ormal), d(etailed), and diag(nostic).")]
         [DefaultValue(VerbosityLevel.Normal)]
         public VerbosityLevel Verbosity { get; set; } = VerbosityLevel.Normal;
     }


### PR DESCRIPTION
- Fix description of verbosity setting.
- Make ConsoleVerbosityWriter class public, so it can be used for testing purposes.